### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore common temporary files
 *~
 *.mo
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore common temporary files
+*~
+*.mo


### PR DESCRIPTION
Some editors create temporary files during an edit session. Some stay behind after a session and others are removed after an edit session is ended.
Also .po-file editors tend to save a compiled version of the po file, as .mo (eg en.po compiles to en.mo)

I have added those I came across when translating, into .gitignore
It makes it easier to avoid including unrelated files.