### PR TITLE
Add missing option and set international units as default

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -68,8 +68,9 @@
             <choices>
                 <choice name="mps"/>
                 <choice name="mph"/>
+                <choice name="kmh"/>
             </choices>
-            <default>1</default>
+            <default>0</default>
         </entry>
         <entry name="timezoneType" type="Enum">
             <choices>


### PR DESCRIPTION
Not sure how big an impact this XML file has, but "km/h" was missing from the choices. Also set international units as standard rather than imperial units.