### PR TITLE
dev-script.sh: Dont install «package/contents/locale/ if it exists»

### DIFF
--- a/dev-build.sh
+++ b/dev-build.sh
@@ -5,12 +5,15 @@ cd $DIR
 
 if [ ! -d build ]; then
   mkdir build
+else
+  rm -fr build/*
 fi
 
-sudo rm -fr build/*
+if [ -d package/contents/locale/ ]; then
+  echo "Folder «package/contents/locale/» exist, removing it"
+  rm -rf package/contents/locale/
+fi
 
-TMP=$(mktemp -d -u)
-mv package/contents/locale $TMP
 pushd  ./build
 
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DKDE_INSTALL_LIBDIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON
@@ -18,4 +21,3 @@ make
 sudo make install
 
 popd
-mv $TMP package/contents/locale


### PR DESCRIPTION
After your explanation in issue #38 I understood your problem.
This change ensures that the  «package/contents/locale/» folder is removed when running the dev-script.sh.