### PR TITLE
Fix cmake warning:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 project(org.kde.weatherWidget-2)
 
 set(QT_MIN_VERSION "5.4.0")


### PR DESCRIPTION
----
CMake Warning (dev) at /usr/share/ECM/modules/ECMFindModuleHelpers.cmake:112 (message):
  Your project should require at least CMake 3.16.0 to use FindKF5.cmake
Call Stack (most recent call first):
  /usr/share/ECM/find-modules/FindKF5.cmake:30 (ecm_find_package_version_check)
  CMakeLists.txt:15 (find_package)
----