### PR TITLE
Fix build error (issue #39 came back)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,6 @@ find_package(Qt5 ${REQUIRED_QT_VERSION} CONFIG REQUIRED Quick)
 find_package(KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS Plasma)
 
 add_subdirectory(plugin)
-add_subdirectory(package/translations)
+add_subdirectory(translations)
 
 plasma_install_package(package org.kde.weatherWidget-2)


### PR DESCRIPTION
Somehow the merge into master reintroduced a build error that was fixed, and I only noticed today when trying to build version 2.2.3.
This patch fixes it, again. :-)