### PR TITLE
Modified URL to display the yr.no-weather forecast

### DIFF
--- a/package/contents/ui/providers/MetNo.qml
+++ b/package/contents/ui/providers/MetNo.qml
@@ -11,6 +11,7 @@ Item {
     property var locale: Qt.locale()
     property string providerId: 'metno'
     property string urlPrefix: 'https://api.met.no/weatherapi/locationforecast/2.0/compact?'
+    property string forecastPrefix: 'https://www.yr.no/en/forecast/daily-table/'
 
     property bool weatherDataFlag: false
     property bool sunRiseSetFlag: false
@@ -19,8 +20,13 @@ Item {
         return i18n("Weather forecast data provided by The Norwegian Meteorological Institute.")
     }
 
+    function extLongLat(placeIdentifier) {
+        return placeIdentifier.substr(placeIdentifier.indexOf("lat=" )+4,placeIdentifier.indexOf("&lon=")-4) +","+
+               placeIdentifier.substr(placeIdentifier.indexOf("&lon=")+5,placeIdentifier.indexOf("&altitude=")-placeIdentifier.indexOf("&lon=")-5)
+    }
+
     function getCreditLink(placeIdentifier) {
-        return urlPrefix + placeIdentifier
+        return forecastPrefix + extLongLat(placeIdentifier)
     }
 
     function loadDataFromInternet(successCallback, failureCallback, locationObject) {


### PR DESCRIPTION
Currently the creditlink of metno opens the raw data website of the metno api.  I tried to bring back the old behaviour as known from the outdated release 1.6.10 to display a human readable weather forecats.

Changes includes a new string "forecastPrefix" that points to a valid url of the yr.no forecast and a new function "extLongLat" that extract the latidude- and longitude  values out of "placeIdentifier" to a geographical point for a suitable input for the website.

Feel free to try it out.