### PR TITLE
KF6: Declare minimum Plasma API version in metadata

### DIFF
--- a/package/metadata.json
+++ b/package/metadata.json
@@ -30,5 +30,6 @@
         "Website": "https://github.com/blackadderkate/weather-widget-2"
     },
     "X-Plasma-API": "declarativeappletscript",
+    "X-Plasma-API-Minimum-Version": "6.0",
     "KPackageStructure": "Plasma/Applet"
 }


### PR DESCRIPTION
This declares the minimum version of Plasma API for this widget to be `6.0` which makes Plasma 6 happier, and now the weather widget should be able to be added to Plasma desktop itself... At least it worked on my VM.

Addresses https://github.com/blackadderkate/weather-widget-2/issues/157#issuecomment-1879367680

![image](https://github.com/blackadderkate/weather-widget-2/assets/22281670/af23f3ac-5201-4d9e-a938-8634f93dcae2)
![image](https://github.com/blackadderkate/weather-widget-2/assets/22281670/16f6dee9-67e4-4c11-80ce-bf95afd8b410)

This is targeted and should be merged against QT6 branch.

For some reason [Porting Plasmoids to KF6](https://develop.kde.org/docs/plasma/widget/porting_kf6/) documentation leaves out this crucial detail for people porting their widgets to be Plasma 6 compatible 😕