### PR TITLE
Pull @galibozek compilation fixes over from AUR into dev-build.sh

### DIFF
--- a/dev-build.sh
+++ b/dev-build.sh
@@ -16,7 +16,7 @@ fi
 
 pushd  ./build
 
-cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DKDE_INSTALL_LIBDIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DQT_MAJOR_VERSION=6
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DQML_INSTALL_DIR=/usr/lib/qt6/qml -DLOCALE_INSTALL_DIR=/usr/share/locale -DCMAKE_BUILD_TYPE=Release -DKDE_INSTALL_LIBDIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DQT_MAJOR_VERSION=6
 make
 if [ $? -eq 0 ]; then
   sudo make install


### PR DESCRIPTION
This pulls the locale installation/compilation fixes by @galibozek from their [AUR package](https://aur.archlinux.org/packages/plasma-applets-weather-widget-2) into the `dev-build.sh` script. It no longer should install locales into root directory rather than `/usr`! 

Really glossed over this particular issue when making this project compile on Plasma 6 😬

Addresses https://github.com/blackadderkate/weather-widget-2/issues/157#issuecomment-1987338387